### PR TITLE
Fix: Improve mobile responsiveness of DashboardPage

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -34,7 +34,7 @@ export const Layout: React.FC<LayoutProps> = ({
         </div>
         
         {/* Main content */}
-        <div className="relative z-10">
+        <div className="relative z-10 min-h-screen">
           {children}
         </div>
       </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -122,14 +122,14 @@ export const DashboardPage: React.FC = () => {
     <Layout background="host">
       <div className="container mx-auto px-4 py-8">
         {/* Header */}
-        <div className="flex justify-between items-center mb-8">
-          <div>
+        <div className="flex flex-col md:flex-row justify-between items-center mb-8">
+          <div className="mb-4 md:mb-0 text-center md:text-left">
             <h1 className="text-3xl font-bold text-white mb-2">Quiz Dashboard</h1>
             <p className="text-white/70">Manage your quizzes and host games</p>
           </div>
           
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2 text-white/70">
+          <div className="flex flex-col md:flex-row items-center gap-4">
+            <div className="flex items-center gap-2 text-white/70 mb-4 md:mb-0">
               <User size={20} />
               <span>{currentUser?.email}</span>
             </div>


### PR DESCRIPTION

This commit addresses two issues:
1. The DashboardPage header is now responsive. On smaller screens, the header elements (title, your email, sign out button) will stack vertically to ensure better visibility and layout. On larger screens, they will remain in a row.
2. The white screen issue when scrolling on pages with less content than the viewport height has been fixed. The main layout container now correctly extends to the full height of the screen, ensuring the background is always visible.